### PR TITLE
Add SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling>=1.27.0", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]
@@ -7,6 +7,8 @@ source = "vcs"
 
 [project]
 name = "jsonschema-specifications"
+license = "MIT"
+license-files = ["COPYING"]
 description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
 requires-python = ">=3.9"
 readme = "README.rst"
@@ -23,10 +25,8 @@ authors = [
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Hatchling `1.27.0` added support for PEP 639 license expressions.
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

_Also removed the `Python :: 3.8` classifier. Support for it was dropped in https://github.com/python-jsonschema/jsonschema-specifications/commit/09f6f17a46ecf03e314df0e6fa14d57db210a549._

Metadata diff
```diff
 ...
+License-Expression: MIT
 License-File: COPYING
 ...
-Classifier: License :: OSI Approved :: MIT License
 ...
-Classifier: Programming Language :: Python :: 3.8
 ...
```